### PR TITLE
bug: close #16

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from .routers import reviser, configurator, develop
+from .routers import reviser, configurator
 
 app = FastAPI()
 
@@ -10,5 +10,4 @@ def root():
 
 
 app.include_router(reviser.router)
-app.include_router(develop.router)
 app.include_router(configurator.router)


### PR DESCRIPTION
Removed import and include_router develop lines to not import develop module.
This fix the problem of cloning the repo from another device that tries to import this module that isn't on the repo